### PR TITLE
Define infrastructure for Selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install -r requirements.txt
 If you need to run whole tests suite, please run 
 
 ```bash
-python suite.py
+python suite.py -testbed_file testbed.yaml
 ```  
 
 If you need to run a particular test, please run
@@ -43,6 +43,8 @@ export PYTHONPATH=$(pwd):${PYTHONPATH}
 python oct/tests/web/sample.py
 ```
 where `oct/tests/web/sample.py` has to be replaced with desired test module.
+
+**_Please note!_** If you run WEB tests, please make sure you run the `chromedriver` binary first.
 
 ## Development of automated tests
 All contributors have to follow 

--- a/oct/browsers.py
+++ b/oct/browsers.py
@@ -1,0 +1,40 @@
+import functools
+import weakref
+import logging
+from typing import Any
+
+from selenium.webdriver import Remote, ChromeOptions
+
+
+_log = logging.getLogger(__name__)
+
+
+class Chrome:
+    """The class is a proxy for ``Remote`` object.
+
+    The class is introduced to manage a browser lifecycle. It means:
+        - lazy browser initialization - open a browser in the case of real interaction
+        - automatic session closing - close a browser while destroying the instance of this object
+
+    It has the same interface that ``Remote`` object from ``selenium.webdriver`` module has.
+    """
+
+    def __init__(self, grid: str) -> None:
+        @functools.lru_cache()
+        def con() -> Remote:
+            _log.info("Starting a browser session. Connect to: %s", grid)
+            return Remote(
+                command_executor=grid, desired_capabilities=ChromeOptions().to_capabilities()
+            )
+
+        self._client = con
+
+        def close(cache: Any) -> None:
+            if cache.cache_info().currsize > 0:
+                _log.info("Closing the browser session. Disconnect from %s", grid)
+                cache().quit()
+
+        weakref.finalize(self, close, self._client)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client(), name)

--- a/oct/tests/__init__.py
+++ b/oct/tests/__init__.py
@@ -1,5 +1,15 @@
-from pyats.aetest import main
+from typing import Dict, Any
+
+from pyats import aetest
+from pyats.topology import loader
+from pyats.topology.testbed import Testbed  # pylint: disable=no-name-in-module
 
 
-def run_testcase() -> None:
-    main()
+def mandatory_aetest_arguments(testbed: Testbed,) -> Dict[str, Any]:
+    return {"testbed": testbed, "grid": testbed.custom["selenium-grid"]}
+
+
+def run_testcase(testbed_file: str = "testbed.yaml") -> None:
+    aetest.main(
+        **mandatory_aetest_arguments(loader.load(testbed_file))  # pylint: disable=no-member
+    )

--- a/oct/tests/web/sample.py
+++ b/oct/tests/web/sample.py
@@ -2,11 +2,15 @@
 from pyats.aetest import Testcase, test
 
 from oct.tests import run_testcase
+from oct.browsers import Chrome
 
 
 class SampleWebTest(Testcase):
     @test
-    def to_be_deleted(self) -> None:
+    def to_be_deleted(self, grid: str) -> None:
+        chrome = Chrome(grid)
+        chrome.get("http://google.com")
+        chrome.refresh()
         print("Please delete me (SampleWebTest) once a real test is added.")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyats==5.1.0
+selenium==3.141.0

--- a/suite.py
+++ b/suite.py
@@ -2,6 +2,9 @@ import sys
 import os
 from pyats import easypy
 
+from pyats.easypy.main import EasypyRuntime
+
+from oct.tests import mandatory_aetest_arguments
 from oct.tests.web import sample as web_sample_test
 from oct.tests.api import sample as api_sample_test
 from oct.tests.deployment import sample as deployment_sample_test
@@ -13,7 +16,7 @@ _web_tests = (web_sample_test,)
 _deployment_tests = (deployment_sample_test,)
 
 
-def main() -> None:
+def main(runtime: EasypyRuntime) -> None:
     for test_module in _api_tests + _web_tests + _deployment_tests:
         full_test_path = test_module.__file__
         easypy.run(  # pylint: disable=no-member
@@ -24,6 +27,7 @@ def main() -> None:
                 )
             ),
             testscript=full_test_path,
+            **mandatory_aetest_arguments(runtime.testbed),
         )
 
 

--- a/testbed.yaml
+++ b/testbed.yaml
@@ -1,0 +1,4 @@
+testbed:
+    name: example_selenium_testbed
+    custom:
+      selenium-grid: http://localhost:9515


### PR DESCRIPTION
The `Remote` class will be used to initiate
Selenium session. A selenium grid URL is
located inside a testbed file.

`Chrome` class will automatically open browser
and destroy it when an instance of the class is
deleted.

Read about why `Remote` class on
https://extsoft.pro/test-webdriver-browser-in-selenium-world/