### PR TITLE
Add structure of Page Objects for registration

### DIFF
--- a/oct/pages/__init__.py
+++ b/oct/pages/__init__.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def not_implemented(instance: Any) -> None:
+    raise RuntimeError(f"Please implement method in {instance.__class__.__name__}")

--- a/oct/pages/base.py
+++ b/oct/pages/base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class Page(ABC):
+    @abstractmethod
+    def open(self) -> None:
+        pass
+
+    @abstractmethod
+    def loaded(self) -> bool:
+        pass

--- a/oct/pages/registration.py
+++ b/oct/pages/registration.py
@@ -1,0 +1,62 @@
+from oct.pages import not_implemented
+from oct.pages.base import Page
+from selenium.webdriver import Remote
+
+
+class PersonalDetails:
+    def type_first_name(self, first_name: str) -> None:
+        not_implemented(self)
+
+    def type_last_name(self, last_name: str) -> None:
+        not_implemented(self)
+
+    def type_email(self, email: str) -> None:
+        not_implemented(self)
+
+    def type_telephone(self, telephone: str) -> None:
+        not_implemented(self)
+
+
+class Password:
+    def type_password(self, password: str) -> None:
+        not_implemented(self)
+
+    def confirm_password(self, password: str) -> None:
+        not_implemented(self)
+
+
+class RegisterAccountPage(Page):
+    def __init__(self, browser: Remote) -> None:
+        self._browser = browser
+        self._details = PersonalDetails()
+        self._password = Password()
+
+    def open(self) -> None:
+        not_implemented(self)
+
+    def loaded(self) -> bool:
+        not_implemented(self)
+
+    def fill_personal_details(
+        self, first_name: str, last_name: str, email: str, telephone: str
+    ) -> None:
+        self._details.type_first_name(first_name)
+        self._details.type_last_name(last_name)
+        self._details.type_email(email)
+        self._details.type_telephone(telephone)
+
+    def fill_password(self, password: str) -> None:
+        self._password.type_password(password)
+        self._password.confirm_password(password)
+
+    def press_continue(self) -> None:
+        # check Privacy and press a button
+        not_implemented(self)
+
+
+class RegistrationSuccessPage(Page):
+    def open(self) -> None:
+        raise RuntimeError("This page can't be open through an URL")
+
+    def loaded(self) -> bool:
+        not_implemented(self)

--- a/oct/tests/web/registration.py
+++ b/oct/tests/web/registration.py
@@ -1,0 +1,23 @@
+# pylint: disable=no-self-use # pyATS-related exclusion
+from pyats.aetest import Testcase, test
+
+from oct.browsers import Chrome
+from oct.tests import run_testcase
+from oct.pages.registration import RegisterAccountPage, RegistrationSuccessPage
+from selenium.webdriver import Remote
+
+
+class Registration(Testcase):
+    @test
+    def test(self, grid: str) -> None:
+        chrome: Remote = Chrome(grid)
+        registration = RegisterAccountPage(chrome)
+        registration.open()
+        registration.fill_personal_details("Jon", "Doe", "jb@jd.com", "123456")
+        registration.fill_password("supersecret")
+        registration.press_continue()
+        assert RegistrationSuccessPage().loaded()
+
+
+if __name__ == "__main__":
+    run_testcase()

--- a/suite.py
+++ b/suite.py
@@ -6,12 +6,13 @@ from pyats.easypy.main import EasypyRuntime
 
 from oct.tests import mandatory_aetest_arguments
 from oct.tests.web import sample as web_sample_test
+from oct.tests.web import registration
 from oct.tests.api import sample as api_sample_test
 from oct.tests.deployment import sample as deployment_sample_test
 
 _api_tests = (api_sample_test,)
 
-_web_tests = (web_sample_test,)
+_web_tests = (web_sample_test, registration)
 
 _deployment_tests = (deployment_sample_test,)
 


### PR DESCRIPTION
`oct/pages/registration` contains all required Page Object to perform
user registration testcase. But all of them are unimplemented now and
will be updated during further development.

`Page` class (from `oct/pages/base.py` has to be used as base class for
all classes which will represent a page.