### PR TITLE
Don't rewrite exit codes during code assessment

### DIFF
--- a/code-assessment.sh
+++ b/code-assessment.sh
@@ -1,15 +1,26 @@
 #!/usr/bin/env bash
-(
-    black --check .
-    pylint oct suite.py
-    flake8 oct suite.py
-    mypy oct suite.py
-) || (
+
+declare -a FAILURES
+
+add_fail() {
+    FAILURES+=("$1")
+}
+
+black --check . || add_fail black
+pylint oct suite.py || add_fail pylint
+flake8 oct suite.py || add_fail flake8
+mypy oct suite.py || add_fail mypy
+
+if [[ ${#FAILURES[@]} -ne 0 ]]; then
     cat <<RESULT
 
 ===================================================
 = Code assessment is failed! Please fix errors!!! =
 ===================================================
+Failed tool(s):
 RESULT
+    for var in "${FAILURES[@]}"; do
+        echo "- ${var}"
+    done
     exit 11
-)
+fi


### PR DESCRIPTION
`pylint` is executed after `black`. And if `black` is failed, but
`pylint` is passed, the final result will be passed. It means that the
exit code of the latest tool in the code assessment decides if the
procedure is failed or not.

The described behavior was changed in a way that code assessment will
fail if at least one of the tools is failed. Now, there is a sequence of
failures. And if it is not empty, it contains names of tools which have
found some inconsistencies within a code base.