### PR TITLE
Use enum to express a rating

### DIFF
--- a/oct/pages/review.py
+++ b/oct/pages/review.py
@@ -1,5 +1,15 @@
+from enum import Enum
+
 from selenium.webdriver import Remote
 from selenium.common.exceptions import NoSuchElementException
+
+
+class Rating(Enum):
+    ONE = 1
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
 
 
 class Review:
@@ -17,12 +27,12 @@ class Review:
         review_field.click()
         review_field.send_keys(review)
 
-    def choose_rating_from_1_to_5(self, rating: int) -> None:
+    def choose_rating(self, rating: Rating) -> None:
         rating_s = self._browser.find_element_by_xpath(
-            f'//*[@id="form-review"]/div[4]/div/input' f"[{rating}]"
+            f'//*[@id="form-review"]/div[4]/div/input' f"[{rating.value}]"
         )
         rating_s.click()
-        rating_s.send_keys(rating)
+        rating_s.send_keys(rating.value)
 
     def press_continue(self) -> None:
         self._browser.find_element_by_class_name("btn-primary").click()

--- a/oct/tests/web/review.py
+++ b/oct/tests/web/review.py
@@ -5,7 +5,7 @@ from pyats.aetest import Testcase, test
 from selenium.webdriver import Remote
 from oct.browsers import Chrome
 from oct.tests import run_testcase
-from oct.pages.review import Review
+from oct.pages.review import Review, Rating
 from oct.pages.product_page import ProductPage
 
 
@@ -19,7 +19,7 @@ class UsersReview(Testcase):
         review_tab = Review(chrome)
         review_tab.type_name("AutoTestBot")
         review_tab.type_review("This review has been wrote by auto test bot!")
-        review_tab.choose_rating_from_1_to_5(3)
+        review_tab.choose_rating(Rating.THREE)
         review_tab.press_continue()
         assert review_tab.successfully_added()
 


### PR DESCRIPTION
All possible ratings were declared within a `Rating` enum.
And this enum has to be used when a rating needs to be set.