### PR TITLE
Implemented affiliate registration test case via API

### DIFF
--- a/oct/tests/api/affiliate_register.py
+++ b/oct/tests/api/affiliate_register.py
@@ -1,0 +1,31 @@
+# pylint: disable=no-self-use # pyATS-related exclusion
+from pyats.aetest import Testcase, test
+import requests
+from oct.tests import run_testcase
+
+
+class AffiliateReg(Testcase):
+    @test
+    def test_affiliate_reg(self) -> None:
+        params = {
+            "firstname": "Alex",
+            "lastname": "Second",
+            "email": "atest122@gmail.com",
+            "telephone": "+380989898989",
+            "company": "Company",
+            "website": "www.company-site.net",
+            "tax": "123456",
+            "payment": "paypal",
+            "paypal": "atest122@gmail.com",
+            "password": "12345",
+            "confirm": "12345",
+            "agree": 1,
+        }
+        register_request = requests.post(
+            "http://localhost/index.php?route=affiliate/register", params
+        )
+        assert "Your Affiliate Account Has Been Created!" in register_request.text
+
+
+if __name__ == "__main__":
+    run_testcase()


### PR DESCRIPTION
The test case implements the registration of a partner account.
Using the post request to the 'https: //localhost/index.php? Route = affiliate / register' page,
the following parameters are transmitted:
	1. "firstname": "Alex",
	2. "lastname": "Second",
	3. "email": "atest122@gmail.com",
	4. "telephone": "+380989898989",
	5. "company": "Company",
	6. "website": "www.company-site.net",
	7. "tax": "123456",
	8. "payment": "paypal",
	9. "paypal": "atest122@gmail.com",
	10. "password": "12345",
	11. "confirm": "12345",
	12. "agree": 1,
In the case of a successful passage, we expect to see on the page in the title:
"Your Affiliate Account Has Been Created!"
Otherwise, the test case will not pass.