### PR TITLE
Implemented contact us test case via API

### DIFF
--- a/oct/tests/api/contact_us.py
+++ b/oct/tests/api/contact_us.py
@@ -1,0 +1,20 @@
+# pylint: disable=no-self-use # pyATS-related exclusion
+from pyats.aetest import Testcase, test
+import requests
+import urllib3
+from oct.tests import run_testcase
+
+
+class ContactUs(Testcase):
+    @test
+    def test_contact_us(self) -> None:
+        parameters = {"name": "Alex", "email": "test@gmail.com", "enquiry": "test data test data"}
+        urllib3.disable_warnings()
+        request = requests.post(
+            "https://192.168.195.143/index.php?route=information/contact", parameters, verify=False
+        )
+        assert "Contact Us" in request.text and "success" in request.url
+
+
+if __name__ == "__main__":
+    run_testcase()


### PR DESCRIPTION
This test case checks the form of communication with the administrator,
 with the help of the post request at the address
 "https://192.168.195.143/index.php?route=information/contact"
the parameters are transmitted
"name": "Alex",
"email": "test @ gmail.com",
"enquiry ":" test data test data".
In case of successful passage, we expect to see in the response text
"Contact Us" and "success" in the url