### PR TITLE
Add review check test case via API

### DIFF
--- a/oct/tests/api/review.py
+++ b/oct/tests/api/review.py
@@ -1,0 +1,26 @@
+# pylint: disable=no-self-use # pyATS-related exclusion
+from pyats.aetest import Testcase, test
+import requests
+from oct.tests import run_testcase
+
+
+class Review(Testcase):
+    @test
+    def test_review(self) -> None:
+        params = {
+            "name": "Solomon",
+            "text": "This is auto test-bot review. This is auto test-bot review.",
+            "rating": "5",
+        }
+
+        review_request = requests.post(
+            "http://localhost/index.php?route=product/product/write&product_id=40", params
+        )
+        assert (
+            "Thank you for your review. It has been submitted to the webmaster for approval."
+            in review_request.text
+        )
+
+
+if __name__ == "__main__":
+    run_testcase()


### PR DESCRIPTION
This test case checks ability to write review via API.
In test case using post request to the
http://localhost/index.php?route=product/product/write&product_id=40
we send parameters:
	1."name": "Solomon",
	2."text": "This is auto test-bot review. This is auto test-bot review.",
	3."rating": "5",
In the case of a successful passage we expect to see a message on
the title of the page:
"Thank you for your review. It has been submitted to the webmaster
for approval."
In the unsuccessful case, the test case won't pass.