### PR TITLE
Add logout logic in 'Login' test case

### DIFF
--- a/oct/tests/api/login.py
+++ b/oct/tests/api/login.py
@@ -1,19 +1,53 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
-from pyats.aetest import Testcase, test
 import requests
-import urllib3
+from pyats.aetest import Testcase, test, setup
 from oct.tests import run_testcase
+from oct.tests.api.registration_pattern import UserRegistration, Identity, Credentials
+from oct.tests.web.creating_emails import EmailsGeneration
 
 
 class Login(Testcase):
+    email = EmailsGeneration().creating_full_email()
+    password = "12345638"
+
+    @setup
+    def create_account(self) -> None:
+        assert "success" in UserRegistration(
+            Identity("Alex", "Ivanov", "+38090890812"), Credentials(self.email, self.password, "0")
+        ).registration_response("192.168.195.143")
+
     @test
-    def test_login(self) -> None:
-        parameters = {"email": "didilov.aleksey@gmail.com", "password": "12345678"}
-        urllib3.disable_warnings()
-        request = requests.post(
-            "https://192.168.195.143/index.php?route=account/login", parameters, verify=False
+    def login_exists_credentials(self) -> None:
+        assert (
+            "Edit Account"
+            in requests.post(
+                "https://192.168.195.143/index.php?route=account/login",
+                {"email": self.email, "password": self.password},
+                verify=False,
+            ).text
         )
-        assert "My Account" in request.text
+
+    @test
+    def login_empty_email_parameter(self) -> None:
+        assert (
+            "Edit Account"
+            not in requests.post(
+                "https://192.168.195.143/index.php?route=account/login",
+                {"email": "", "password": self.password},
+                verify=False,
+            ).text
+        )
+
+    @test
+    def login_empty_password_parameter(self) -> None:
+        assert (
+            "Edit Account"
+            not in requests.post(
+                "https://192.168.195.143/index.php?route=account/login",
+                {"email": self.email, "password": ""},
+                verify=False,
+            ).text
+        )
 
 
 if __name__ == "__main__":

--- a/oct/tests/api/registration.py
+++ b/oct/tests/api/registration.py
@@ -1,25 +1,17 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
 from pyats.aetest import Testcase, test
-import requests
 from oct.tests import run_testcase
+from oct.tests.api.registration_pattern import UserRegistration, Identity, Credentials
+from oct.tests.web.creating_emails import EmailsGeneration
 
 
 class Registration(Testcase):
     @test
-    def test_registration(self) -> None:
-        parameters = {
-            "customer_group_id": 1,
-            "firstname": "Alex",
-            "lastname": "Aleks",
-            "email": "asttwe227@gmail.com",
-            "telephone": "+380989898989",
-            "password": "1234",
-            "confirm": "1234",
-            "newsletter": 0,
-            "agree": 1,
-        }
-        request = requests.post("http://localhost/index.php?route=account/register", parameters)
-        assert "Your Account Has Been Created!" in request.text
+    def registration_positive_test(self) -> None:
+        assert "success" in UserRegistration(
+            Identity("Alex", "Ivanov", "+38090890812"),
+            Credentials(EmailsGeneration().creating_full_email(), "12345678", "0"),
+        ).registration_response("192.168.195.143")
 
 
 if __name__ == "__main__":

--- a/oct/tests/api/registration_pattern.py
+++ b/oct/tests/api/registration_pattern.py
@@ -1,0 +1,58 @@
+import urllib3
+import requests
+
+
+class Identity:
+    def __init__(self, first_name: str, last_name: str, telephone: str):
+        self._first_name = first_name
+        self._last_name = last_name
+        self._telephone = telephone
+
+    def get_first_name(self) -> str:
+        return self._first_name
+
+    def get_last_name(self) -> str:
+        return self._last_name
+
+    def get_telephone(self) -> str:
+        return self._telephone
+
+
+class Credentials:
+    def __init__(self, email: str, password: str, news_letter: str):
+        self._email = email
+        self._password = password
+        self._news_letter = news_letter
+
+    def get_email(self) -> str:
+        return self._email
+
+    def get_password(self) -> str:
+        return self._password
+
+    def get_newsletter(self) -> str:
+        return self._news_letter
+
+
+class UserRegistration:
+    def __init__(self, identity: Identity, credentials: Credentials):
+        self._identity = identity
+        self._credentials = credentials
+
+    def registration_response(self, domain_name: str) -> str:
+        urllib3.disable_warnings()
+        return requests.post(
+            f"https://{domain_name}//index.php?route=account/register",
+            {
+                "customer_group_id": "1",
+                "firstname": self._identity.get_first_name(),
+                "lastname": self._identity.get_last_name(),
+                "email": self._credentials.get_email(),
+                "telephone": self._identity.get_telephone(),
+                "password": self._credentials.get_password(),
+                "confirm": self._credentials.get_password(),
+                "newsletter": self._credentials.get_newsletter(),
+                "agree": "1",
+            },
+            verify=False,
+        ).url

--- a/oct/tests/web/login.py
+++ b/oct/tests/web/login.py
@@ -1,21 +1,50 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
-from pyats.aetest import Testcase, test
+from pyats.aetest import Testcase, test, setup
 from selenium.webdriver import Remote
 from oct.browsers import Chrome
 from oct.tests import run_testcase
 from oct.pages.login import LoginPage
 from oct.pages.account import AccountPage
+from oct.tests.api.registration_pattern import UserRegistration, Identity, Credentials
+from oct.tests.web.creating_emails import EmailsGeneration
 
 
 class Login(Testcase):
+    email = EmailsGeneration().creating_full_email()
+    password = "12345678"
+
+    @setup
+    def create_account(self) -> None:
+        assert "success" in UserRegistration(
+            Identity("Alex", "Ivanov", "+38090890812"), Credentials(self.email, self.password, "0")
+        ).registration_response("localhost")
+
     @test
     def login_exists_credentials(self, grid: str) -> None:
         chrome: Remote = Chrome(grid)
         login = LoginPage(chrome)
         login.open()
-        login.fill_credentials("didilov.aleksey@gmail.com", "12345678")
+        login.fill_credentials(self.email, self.password)
         login.press_login_button()
         assert AccountPage(chrome).loaded()
+
+    @test
+    def login_nonexistent_email(self, grid: str) -> None:
+        chrome: Remote = Chrome(grid)
+        login = LoginPage(chrome)
+        login.open()
+        login.fill_credentials("Er12asd@mailinator.com", self.password)
+        login.press_login_button()
+        assert not AccountPage(chrome).loaded()
+
+    @test
+    def login_nonexistent_password(self, grid: str) -> None:
+        chrome: Remote = Chrome(grid)
+        login = LoginPage(chrome)
+        login.open()
+        login.fill_credentials(self.email, "12345789")
+        login.press_login_button()
+        assert not AccountPage(chrome).loaded()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Login test case was implemented for checking ability to
login into user account (with valid credentials). After
checking that user logged into account, need to make
logout, for prevent conflicts with test cases where
logout isn't used.

Logout link located in drop-down menu in Header. For
ability to work with this link, 'Header' page was
implemented in oct/pages. #26