### PR TITLE
Configure execution sequence for WEB and API tests

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -1,27 +1,25 @@
 # pylint: disable=no-value-for-parameter
 import sys
 import os
+from typing import List, Tuple, Any
 from pyats import easypy
 
 from pyats.easypy.main import EasypyRuntime
 
 from oct.tests import mandatory_aetest_arguments
-from oct.tests.web import sample as web_sample_test
-from oct.tests.web import registration
-from oct.tests.api import registration as api_sample_test
-from oct.tests.deployment import deploy_app as deployment_sample_test
+from oct.tests.web import review as web_review
+from oct.tests.api import forgot_passwrd, review
 
-_api_tests = (api_sample_test,)
+_api_tests = (review, forgot_passwrd)
 
-_web_tests = (web_sample_test, registration)
-
-_deployment_tests = (deployment_sample_test,)
+_web_tests = (web_review,)
 
 
-def main(runtime: EasypyRuntime) -> None:
-    for test_module in _api_tests + _web_tests + _deployment_tests:
+def tests_runner(test_suite: Tuple, instance: Any) -> List:  # type: ignore
+    test_suite_results = list()
+    for test_module in test_suite:
         full_test_path = test_module.__file__
-        easypy.run(  # pylint: disable=no-member
+        test_result = easypy.run(  # pylint: disable=no-member
             taskid=" -> ".join(
                 (
                     os.path.dirname(full_test_path).split(os.sep)[-1],
@@ -29,8 +27,15 @@ def main(runtime: EasypyRuntime) -> None:
                 )
             ),
             testscript=full_test_path,
-            **mandatory_aetest_arguments(runtime.testbed, device_name="vm"),
+            **mandatory_aetest_arguments(instance, device_name="vm"),
         )
+        test_suite_results.append(str(test_result))
+    return test_suite_results
+
+
+def main(runtime: EasypyRuntime) -> None:
+    if "failed" not in tests_runner(_api_tests, runtime.testbed):
+        tests_runner(_web_tests, runtime.testbed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
File was configured to run tests in next sequence:
1. API test suite
2. WEB test suite

Only if API test suite is passed, will run WEB test suite. It's means
that, if one or more tests from API test suite has failed, WEB test suite
will skipped.