### PR TITLE
destroy_app testcase implemented

### DIFF
--- a/oct/tests/__init__.py
+++ b/oct/tests/__init__.py
@@ -11,6 +11,7 @@ def mandatory_aetest_arguments(testbed: Testbed, device_name: str) -> Dict[str, 
         "testbed": testbed,
         "grid": testbed.custom["selenium-grid"],
         "device": testbed.devices[device_name],
+        "server": testbed.devices[device_name],
     }
 
 

--- a/oct/tests/deployment/deploy_app.py
+++ b/oct/tests/deployment/deploy_app.py
@@ -18,12 +18,12 @@ def copy_file_to_server(device: Device) -> None:
     )
 
 
-def is_deploy_app(device: Device) -> bool:
+def is_deploy_app(device: Device, lines: int) -> bool:
     non_empty_lines_counter = 0
     for iterator in device.execute("docker-compose ps -q"):
         if iterator == "\n":
             non_empty_lines_counter += 1
-    return non_empty_lines_counter == 2
+    return non_empty_lines_counter == lines
 
 
 class DeployApp(Testcase):
@@ -35,7 +35,7 @@ class DeployApp(Testcase):
             copy_file_to_server(device)
             device.execute("cd oct")
             device.execute(f"APP_HOST={device.connections.main.ip} docker-compose up -d")
-            assert is_deploy_app(device)
+            assert is_deploy_app(device, 2)
         except ConnectTimeout:
             self.failed()
         finally:

--- a/oct/tests/deployment/destroy_app.py
+++ b/oct/tests/deployment/destroy_app.py
@@ -1,0 +1,30 @@
+# pylint: disable=no-self-use # pyATS-related exclusion
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=too-many-branches
+# pylint: disable=duplicate-code
+from pyats.topology import Device
+from pyats.aetest import Testcase, test
+from requests.exceptions import ConnectTimeout, ReadTimeout
+from oct.tests import run_testcase
+from oct.tests.deployment.deploy_app import is_deploy_app
+
+
+class DestroyApp(Testcase):
+    @test
+    def destroy_app(self, server: Device) -> None:
+        try:
+            server.connect()
+            server.execute("cd oct")
+            server.execute("docker-compose down")
+            assert is_deploy_app(server, 0)
+            server.execute("cd ~")
+            server.execute("rm -rf oct")
+        except (ConnectTimeout, ReadTimeout):
+            self.failed()
+        finally:
+            server.disconnect()
+
+
+if __name__ == "__main__":
+    run_testcase()


### PR DESCRIPTION
This test turns off the docker on the server and after that deletes
the oct folder. In deploy_app.py testcase is_deploy_app function is
changed accepts int number for the number of lines to search
Steps:
    Run docker-compose down
    APP_HOST= docker-compose ps -q should return nothing
    Remove oct
Implemented task #24