### PR TITLE
Add domain name in url in api tests

### DIFF
--- a/oct/tests/api/affiliate_register.py
+++ b/oct/tests/api/affiliate_register.py
@@ -1,30 +1,35 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
-from pyats.aetest import Testcase, test
+import urllib3
 import requests
+from pyats.aetest import test, Testcase
+from pyats.topology import Device
 from oct.tests import run_testcase
 
 
 class AffiliateReg(Testcase):
     @test
-    def test_affiliate_reg(self) -> None:
+    def test_affiliate_reg(self, device: Device) -> None:
+        urllib3.disable_warnings()
         params = {
             "firstname": "Alex",
             "lastname": "Second",
-            "email": "atest122@gmail.com",
+            "email": "ates122@gmail.com",
             "telephone": "+380989898989",
             "company": "Company",
             "website": "www.company-site.net",
             "tax": "123456",
             "payment": "paypal",
-            "paypal": "atest122@gmail.com",
+            "paypal": "atet122@gmail.com",
             "password": "12345",
             "confirm": "12345",
             "agree": 1,
         }
         register_request = requests.post(
-            "http://localhost/index.php?route=affiliate/register", params
+            f"https://{device.connections.main.ip}/index.php?route=affiliate/register",
+            params,
+            verify=False,
         )
-        assert "Your Affiliate Account Has Been Created!" in register_request.text
+        assert "success" in register_request.url
 
 
 if __name__ == "__main__":

--- a/oct/tests/api/contact_us.py
+++ b/oct/tests/api/contact_us.py
@@ -1,19 +1,22 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
+import urllib3
+from pyats.topology import Device
 from pyats.aetest import Testcase, test
 import requests
-import urllib3
 from oct.tests import run_testcase
 
 
 class ContactUs(Testcase):
     @test
-    def test_contact_us(self) -> None:
+    def test_contact_us(self, device: Device) -> None:
         parameters = {"name": "Alex", "email": "test@gmail.com", "enquiry": "test data test data"}
         urllib3.disable_warnings()
         request = requests.post(
-            "https://192.168.195.143/index.php?route=information/contact", parameters, verify=False
+            f"https://{device.connections.main.ip}/index.php?route=information/contact",
+            parameters,
+            verify=False,
         )
-        assert "Contact Us" in request.text and "success" in request.url
+        assert "success" in request.url
 
 
 if __name__ == "__main__":

--- a/oct/tests/api/forgot_passwrd.py
+++ b/oct/tests/api/forgot_passwrd.py
@@ -1,26 +1,31 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
-from pyats.aetest import Testcase, test
-import requests
 import urllib3
+from pyats.aetest import Testcase, test
+from pyats.topology import Device
+import requests
 from oct.tests import run_testcase
 
 
 class ForgotPassword(Testcase):
     @test
-    def test_forgot_password_for_known_user(self) -> None:
+    def test_forgot_password_for_known_user(self, device: Device) -> None:
         parameters = {"email": "testerwom@gmail.com"}
         urllib3.disable_warnings()
         request = requests.post(
-            "https://localhost/index.php?route=account/forgotten", parameters, verify=False
+            f"https://{device.connections.main.ip}/index.php?route=account/forgotten",
+            parameters,
+            verify=False,
         )
         assert "An email with a confirmation link has been sent your email address." in request.text
 
     @test
-    def test_forgot_password_for_unknown_user(self) -> None:
+    def test_forgot_password_for_unknown_user(self, device: Device) -> None:
         parameters = {"email": "someemailll@gmail.com"}
         urllib3.disable_warnings()
         request = requests.post(
-            "https://localhost/index.php?route=account/forgotten", parameters, verify=False
+            f"https://{device.connections.main.ip}/index.php?route=account/forgotten",
+            parameters,
+            verify=False,
         )
         assert "The E-Mail Address was not found in our records, please try again!" in request.text
 

--- a/oct/tests/api/gift_certificate.py
+++ b/oct/tests/api/gift_certificate.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
+from pyats.topology import Device
 from pyats.aetest import Testcase, test
 import requests
 import urllib3
@@ -7,7 +8,7 @@ from oct.tests import run_testcase
 
 class GiftCertificate(Testcase):
     @test
-    def test_gift_certificate(self) -> None:
+    def test_gift_certificate(self, device: Device) -> None:
         urllib3.disable_warnings()
         parameters = {
             "to_name": "green22",
@@ -20,7 +21,9 @@ class GiftCertificate(Testcase):
             "agree": 1,
         }
         gift_request = requests.post(
-            "https://192.168.195.143/index.php?route=account/voucher", parameters, verify=False
+            f"https://{device.connections.main.ip}/index.php?route=account/voucher",
+            parameters,
+            verify=False,
         )
         assert "success" in gift_request.url
 

--- a/oct/tests/api/login.py
+++ b/oct/tests/api/login.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
 import requests
 from pyats.aetest import Testcase, test, setup
+from pyats.topology import Device
 from oct.tests import run_testcase
 from oct.tests.api.registration_pattern import UserRegistration, Identity, Credentials
 from oct.tests.web.creating_emails import EmailsGeneration
@@ -11,39 +12,39 @@ class Login(Testcase):
     password = "12345638"
 
     @setup
-    def create_account(self) -> None:
+    def create_account(self, device: Device) -> None:
         assert "success" in UserRegistration(
             Identity("Alex", "Ivanov", "+38090890812"), Credentials(self.email, self.password, "0")
-        ).registration_response("192.168.195.143")
+        ).registration_response(device.connections.main.ip)
 
     @test
-    def login_exists_credentials(self) -> None:
+    def login_exists_credentials(self, device: Device) -> None:
         assert (
             "Edit Account"
             in requests.post(
-                "https://192.168.195.143/index.php?route=account/login",
+                f"https://{device.connections.main.ip}/index.php?route=account/login",
                 {"email": self.email, "password": self.password},
                 verify=False,
             ).text
         )
 
     @test
-    def login_empty_email_parameter(self) -> None:
+    def login_empty_email_parameter(self, device: Device) -> None:
         assert (
             "Edit Account"
             not in requests.post(
-                "https://192.168.195.143/index.php?route=account/login",
+                f"https://{device.connections.main.ip}/index.php?route=account/login",
                 {"email": "", "password": self.password},
                 verify=False,
             ).text
         )
 
     @test
-    def login_empty_password_parameter(self) -> None:
+    def login_empty_password_parameter(self, device: Device) -> None:
         assert (
             "Edit Account"
             not in requests.post(
-                "https://192.168.195.143/index.php?route=account/login",
+                f"https://{device.connections.main.ip}/index.php?route=account/login",
                 {"email": self.email, "password": ""},
                 verify=False,
             ).text

--- a/oct/tests/api/registration.py
+++ b/oct/tests/api/registration.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
 from pyats.aetest import Testcase, test
+from pyats.topology import Device
 from oct.tests import run_testcase
 from oct.tests.api.registration_pattern import UserRegistration, Identity, Credentials
 from oct.tests.web.creating_emails import EmailsGeneration
@@ -7,11 +8,11 @@ from oct.tests.web.creating_emails import EmailsGeneration
 
 class Registration(Testcase):
     @test
-    def registration_positive_test(self) -> None:
+    def registration_positive_test(self, device: Device) -> None:
         assert "success" in UserRegistration(
             Identity("Alex", "Ivanov", "+38090890812"),
             Credentials(EmailsGeneration().creating_full_email(), "12345678", "0"),
-        ).registration_response("192.168.195.143")
+        ).registration_response(device.connections.main.ip)
 
 
 if __name__ == "__main__":

--- a/oct/tests/api/returns.py
+++ b/oct/tests/api/returns.py
@@ -1,30 +1,32 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
-from pyats.aetest import Testcase, test
-import requests
 import urllib3
+import requests
+from pyats.aetest import Testcase, test
+from pyats.topology import Device
 from oct.tests import run_testcase
 
 
 class Returns(Testcase):
     @test
-    def test_returns(self) -> None:
-        parameters = {
-            "firstname": "Alex",
-            "lastname": "Petrov",
-            "email": "newaddr@gmail.com",
-            "telephone": "+380963453377",
-            "order_id": "1234",
-            "date_ordered": "2019-03-22",
-            "product": "apple",
-            "model": "Imac",
-            "quantity": 1,
-            "return_reason_id": 4,
-            "opened": 1,
-            "comment": "New item has some scratches",
-        }
+    def test_returns(self, device: Device) -> None:
         urllib3.disable_warnings()
         request = requests.post(
-            "https://192.168.195.143/index.php?route=account/return/add", parameters, verify=False
+            f"https://{device.connections.main.ip}/index.php?route=account/return/add",
+            {
+                "firstname": "Alex",
+                "lastname": "Petrov",
+                "email": "newaddr@gmail.com",
+                "telephone": "+380963453377",
+                "order_id": "1234",
+                "date_ordered": "2019-03-22",
+                "product": "apple",
+                "model": "Imac",
+                "quantity": 1,
+                "return_reason_id": 4,
+                "opened": 1,
+                "comment": "New item has some scratches",
+            },
+            verify=False,
         )
         assert (
             "Thank you for submitting your return request."

--- a/oct/tests/api/review.py
+++ b/oct/tests/api/review.py
@@ -1,20 +1,25 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
-from pyats.aetest import Testcase, test
+import urllib3
 import requests
+from pyats.topology import Device
+from pyats.aetest import Testcase, test
 from oct.tests import run_testcase
 
 
 class Review(Testcase):
     @test
-    def test_review(self) -> None:
+    def test_review(self, device: Device) -> None:
         params = {
             "name": "Solomon",
             "text": "This is auto test-bot review. This is auto test-bot review.",
             "rating": "5",
         }
-
+        urllib3.disable_warnings()
         review_request = requests.post(
-            "http://localhost/index.php?route=product/product/write&product_id=40", params
+            f"https://{device.connections.main.ip}/"
+            f"index.php?route=product/product/write&product_id=40",
+            params,
+            verify=False,
         )
         assert (
             "Thank you for your review. It has been submitted to the webmaster for approval."


### PR DESCRIPTION
API test was updated, url with 'local' domain names was replaced
on 'vm' domain name, for ability to run on remote vm.