### PR TITLE
Vagrantfile created

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,38 @@ In order to run code assessment, you need to run `./code-assessment.sh` command 
 that there is no message like **_Code assessment is failed! Please fix errors!!!_**. If you face
 the massage, please fix all violations.
 
+### Creating a virtual machine for application using Vagrant 
+To be able to use this type of run, you need to have Vagrant engine release 2.2.4+ and Virtualbox 
+engine release  5.2.28+. 
+
+A simple way to check Vagrant: 
+```bash
+vagrant --version
+```
+
+A simple way to check Virtualbox:
+```bash
+vboxmanage --version
+``` 
+
+First of all, you need to run:
+```bash
+vagrant up
+```
+
+Then you can run  `suite.py` to run all tests 
+
+
+If you want to shutdown vm you must run:
+```bash
+vagrant halt
+``` 
+
+If you want to delete vm you must run:
+```bash
+vagrant destroy
+```
+
 ### Deploy and destroy application
 If you want to deploy the application to localhost, you need to run in the terminal
 ```bash
@@ -97,3 +129,7 @@ If you need to destroy application, run in the terminal
 ```bash
 sudo docker-compose down
 ```
+
+
+
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,10 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu1804"
+  config.vm.define "dp-151"
+  config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.provision :docker
+  config.vm.provision :docker_compose
+  config.vm.provider "virtualbox" do |v|
+    v.name = "dp-151_app"
+  end
+end

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,5 +19,6 @@ services:
       kompose.service.type: nodeport
     ports:
       - '443:443'
+      - '80:80'
     depends_on:
       - mariadb

--- a/oct/tests/deployment/deploy_app.py
+++ b/oct/tests/deployment/deploy_app.py
@@ -14,7 +14,7 @@ def copy_file_to_server(device: Device) -> None:
     futils = FileUtils(testbed=device.testbed)
     futils.copyfile(
         source=f"{os.path.join(os.getcwd(), 'docker-compose.yaml')}",
-        destination=f"scp://{device.connections.main.ip}/home/adminaccount/oct",
+        destination=f"scp://{device.connections.main.ip}/home/vagrant/oct",
     )
 
 

--- a/testbed.yaml
+++ b/testbed.yaml
@@ -4,9 +4,9 @@ testbed:
       selenium-grid: http://localhost:9515
     servers:
       server_alias:
-        address: 192.168.195.143
-        username: adminaccount
-        password: Install_new!
+        address: 192.168.33.10
+        username: vagrant
+        password: vagrant
 devices:
     vm:
         os: 'linux'
@@ -15,8 +15,8 @@ devices:
                 via: main
                 alias: default
             main:
-                username: adminaccount
+                username: vagrant
                 protocol: ssh
-                ip: 192.168.195.143
-                password: Install_new!
+                ip: 192.168.33.10
+                password: vagrant
         type: 'linux'


### PR DESCRIPTION
Vagrantfile created, with the help of vagrant you can running vm on your pc

Settings:
linux = Ubuntu 18.04
IP = 192.168.33.10
VM name = dp-151_app
username = vagrant
password = vagrant

Instruction:
To be able to use this type of run, you need to have Vagrant engine release 2.2.4+ and Virtualbox
engine release  5.2.28+.

A simple way to check Vagrant:
```bash
vagrant --version
```

A simple way to check Virtualbox:
```bash
vboxmanage --version
```
First of all, you need to run:
```bash
vagrant up
```

Then you can run  `suite.py` to run all tests

If you want to shutdown vm you must run:
```bash
vagrant halt
```

If you want to delete vm you must run:
```bash
vagrant destroy
```

Changes in other files:
testbed.yaml:
  - adress changed to 192.168.33.10
  - username changed to vagrant
  - password changed to vagrant

docker-compose.yaml:
  - addded http port

deploy_app.py:
  - username changed to vagrant