### PR TITLE
This commit upgrade urllib3 to 1.24.2 and added modules scp and paramico

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 pyats==5.1.0
 selenium==3.141.0
 requests==2.21.0
-urllib3==1.24.1
+urllib3==1.24.2
+paramiko==2.4.2
+scp==0.13.2
+


### PR DESCRIPTION
Changes in requirements.txt:
1. urllib3 upgraded to 1.24.2 version. Issue #69 implemented
2. Added module paramiko (needed for deploy test)
3. Added module scp (needed for deploy test)