### PR TITLE
Allow `oct` module execution by default

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
+
 [flake8]
 max-complexity = 5
 max-line-length = 100

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install -r requirements.txt
 If you need to run whole tests suite, please run 
 
 ```bash
-python suite.py -testbed_file testbed.yaml
+python -m oct -testbed_file testbed.yaml
 ```  
 
 If you need to run a particular test, please run

--- a/code-assessment.sh
+++ b/code-assessment.sh
@@ -7,9 +7,9 @@ add_fail() {
 }
 
 black --check . || add_fail black
-pylint oct suite.py || add_fail pylint
-flake8 oct suite.py || add_fail flake8
-mypy oct suite.py || add_fail mypy
+pylint oct || add_fail pylint
+flake8 oct || add_fail flake8
+mypy  oct || add_fail mypy
 py.test -v tests || add_fail py.test
 if [[ ${#FAILURES[@]} -ne 0 ]]; then
     cat <<RESULT

--- a/oct/__main__.py
+++ b/oct/__main__.py
@@ -102,9 +102,9 @@ if __name__ == "__main__":
     # This configuration allow to replace `easypy` with a Python runner.
     #
     # It means that
-    #    easypy suite.py.py <...>
+    #    easypy -m oct <...>
     # you can replace with
-    #    python suite.py.py <...>
+    #    python -m oct <...>
     # where <...> are easypy's arguments.
     #
     # We add a name of this module as first parameter to the `sys.argv`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ black==18.9b0
 pylint==2.3.1
 flake8-docstrings==1.3.0
 mypy==0.670
+pydocstyle<3.0.0


### PR DESCRIPTION
This commit implemented issue #86
all form suite.py migrated to oct/__main__.py
Readme updated changed running command to 'python -m oct'