### PR TITLE
Allow `oct` module execution by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install -r requirements.txt
 If you need to run whole tests suite, please run 
 
 ```bash
-python suite.py -testbed_file testbed.yaml
+python -m oct -testbed_file testbed.yaml
 ```  
 
 If you need to run a particular test, please run

--- a/code-assessment.sh
+++ b/code-assessment.sh
@@ -7,10 +7,10 @@ add_fail() {
 }
 
 black --check . || add_fail black
-pylint oct suite.py || add_fail pylint
-flake8 oct suite.py || add_fail flake8
-pydocstyle oct suite.py || add_fail pydocstyle
-mypy oct suite.py || add_fail mypy
+pylint oct || add_fail pylint
+flake8 oct || add_fail flake8
+pydocstyle oct || add_fail pydocstyle
+mypy oct || add_fail mypy
 py.test -v tests || add_fail py.test
 if [[ ${#FAILURES[@]} -ne 0 ]]; then
     cat <<RESULT

--- a/oct/__main__.py
+++ b/oct/__main__.py
@@ -102,9 +102,9 @@ if __name__ == "__main__":
     # This configuration allow to replace `easypy` with a Python runner.
     #
     # It means that
-    #    easypy suite.py.py <...>
+    #    easypy oct/__main__.py <...>
     # you can replace with
-    #    python suite.py.py <...>
+    #    python -m oct <...>
     # where <...> are easypy's arguments.
     #
     # We add a name of this module as first parameter to the `sys.argv`


### PR DESCRIPTION
This commit implement issue #86
All from suite.py migrated to oct/main.py
Readme update, change command to run all tests
from:
 -  'python suite.py'
to:
 -  'python -m oct'