### PR TITLE
Remove the ability to create mail with creating_emails.py

### DIFF
--- a/oct/__main__.py
+++ b/oct/__main__.py
@@ -15,7 +15,6 @@ from oct.tests.web import affiliate_register as web_affiliate_register_test
 from oct.tests.web import all_brands
 from oct.tests.web import brand
 from oct.tests.web import contact_us as web_contact_us_test
-from oct.tests.web import creating_emails
 from oct.tests.web import forgot_password_test
 from oct.tests.web import gift_certificate as web_gift_certificate_test
 from oct.tests.web import login as web_login_test
@@ -56,7 +55,6 @@ _web_tests = (
     all_brands,
     brand,
     web_contact_us_test,
-    creating_emails,
     forgot_password_test,
     web_gift_certificate_test,
     web_login_test,

--- a/oct/tests/api/affiliate_register.py
+++ b/oct/tests/api/affiliate_register.py
@@ -25,23 +25,23 @@ class AffiliateReg(Testcase):
     @test
     def test_affiliate_reg(self, device: Device) -> None:
         urllib3.disable_warnings()
-        generator = Person()
+        person = Person()
         (
             assert_if_request_contains_success_response_url(
                 Post(
                     f"https://{device.connections.main.ip}/index.php?route=affiliate/register",
                     {
-                        "firstname": generator.name(),
-                        "lastname": generator.last_name(),
-                        "email": generator.email(),
-                        "telephone": generator.telephone(),
-                        "company": generator.full_name(),
-                        "website": f"www.{generator.username()}.net",
+                        "firstname": person.name(),
+                        "lastname": person.last_name(),
+                        "email": person.email(),
+                        "telephone": person.telephone(),
+                        "company": person.full_name(),
+                        "website": f"www.{person.username()}.net",
                         "tax": "123456",
                         "payment": "paypal",
-                        "paypal": generator.email(),
-                        "password": generator.password(),
-                        "confirm": generator.password(),
+                        "paypal": person.email(),
+                        "password": person.password(),
+                        "confirm": person.password(),
                         "agree": 1,
                     },
                 )

--- a/oct/tests/api/contact_us.py
+++ b/oct/tests/api/contact_us.py
@@ -9,15 +9,11 @@ from oct.tests.api.affiliate_register import assert_if_request_contains_success_
 class ContactUs(Testcase):
     @test
     def test_contact_us(self, device: Device) -> None:
-        generator = Person()
+        person = Person()
         assert_if_request_contains_success_response_url(
             Post(
                 f"https://{device.connections.main.ip}/index.php?route=information/contact",
-                {
-                    "name": generator.name(),
-                    "email": generator.email(),
-                    "enquiry": "test data test data",
-                },
+                {"name": person.name(), "email": person.email(), "enquiry": "test data test data"},
             )
         )
 

--- a/oct/tests/api/forgot_passwrd.py
+++ b/oct/tests/api/forgot_passwrd.py
@@ -1,15 +1,15 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
+from mimesis import Person
 import urllib3
 from pyats.aetest import Testcase, test, setup
 from pyats.topology import Device
 import requests
 from oct.tests import run_testcase
 from oct.tests.api.registration_pattern import UserRegistration, Identity, Credentials
-from oct.tests.web.creating_emails import EmailsGeneration
 
 
 class ForgotPassword(Testcase):
-    email = EmailsGeneration().creating_full_email()
+    email = Person().email()
     password = "12345678"
 
     @setup

--- a/oct/tests/api/login.py
+++ b/oct/tests/api/login.py
@@ -8,14 +8,14 @@ from oct.tests.api.registration_pattern import UserRegistration, Identity, Crede
 
 
 class Login(Testcase):
-    generator = Person()
-    email = generator.email()
-    password = generator.password()
+    person = Person()
+    email = person.email()
+    password = person.password()
 
     @setup
     def create_account(self, device: Device) -> None:
         assert "success" in UserRegistration(
-            Identity(self.generator.name(), self.generator.last_name(), self.generator.telephone()),
+            Identity(self.person.name(), self.person.last_name(), self.person.telephone()),
             Credentials(self.email, self.password, "0"),
         ).registration_response(device)
 

--- a/oct/tests/web/affiliate_register.py
+++ b/oct/tests/web/affiliate_register.py
@@ -14,19 +14,16 @@ class RegistrationAffiliate(Testcase):
     def test(self, grid: str, device: Device) -> None:
         chrome: Remote = Chrome(grid)
         registration = RegisterAffiliatePage(chrome)
-        generator = Person()
+        person = Person()
         registration.load(device)
         registration.fill_personal_details(
-            generator.name(), generator.last_name(), generator.email(), generator.telephone()
+            person.name(), person.last_name(), person.email(), person.telephone()
         )
         registration.press_pay_method()
         registration.fill_information(
-            generator.full_name(),
-            f"www.{generator.username()}.com",
-            "2332153467",
-            generator.email(),
+            person.full_name(), f"www.{person.username()}.com", "2332153467", person.email()
         )
-        registration.fill_password(generator.password())
+        registration.fill_password(person.password())
         registration.press_continue()
         assert RegAffiliateSuccessPage(chrome).available()
 

--- a/oct/tests/web/contact_us.py
+++ b/oct/tests/web/contact_us.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
 
-
+from mimesis import Person
 from pyats.aetest import Testcase, test
 from pyats.topology import Device
 from selenium.webdriver import Remote
@@ -13,9 +13,10 @@ class ContactUs(Testcase):
     @test
     def test(self, grid: str, device: Device) -> None:
         chrome: Remote = Chrome(grid)
+        person = Person()
         contact_us = ContactUsPage(chrome)
         contact_us.load(device)
-        contact_us.fill_contact_details("Alex", "alex@gmail.com", "Test data test data")
+        contact_us.fill_contact_details(person.name(), person.email(), "Test data test data")
         contact_us.press_submit()
         assert ContactUsSuccessPage(chrome).available()
 

--- a/oct/tests/web/creating_emails.py
+++ b/oct/tests/web/creating_emails.py
@@ -1,9 +1,0 @@
-# pylint: disable=no-self-use # pyATS-related exclusion
-import random
-import string
-
-
-class EmailsGeneration:
-    def creating_full_email(self) -> str:
-        first_part_of_email = str("".join(random.choice(string.ascii_letters) for _ in range(7)))
-        return "".join(list(first_part_of_email + "@mailinator.com"))

--- a/oct/tests/web/forgot_password_test.py
+++ b/oct/tests/web/forgot_password_test.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
+from mimesis import Person
 from selenium.webdriver import Remote
 from pyats.topology import Device
 from pyats.aetest import Testcase, test, setup
@@ -6,11 +7,10 @@ from oct.browsers import Chrome
 from oct.tests import run_testcase
 from oct.pages.forgot_password import ForgotPasswordPage, ConfirmationMessage
 from oct.tests.api.registration_pattern import UserRegistration, Identity, Credentials
-from oct.tests.web.creating_emails import EmailsGeneration
 
 
 class ForgotPassword(Testcase):
-    email = EmailsGeneration().creating_full_email()
+    email = Person().email()
     password = "12345wer8"
 
     @setup

--- a/oct/tests/web/login.py
+++ b/oct/tests/web/login.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-self-use # pyATS-related exclusion
+from mimesis import Person
 from pyats.aetest import Testcase, test, setup
 from pyats.topology import Device
 from selenium.webdriver import Remote
@@ -7,11 +8,10 @@ from oct.tests import run_testcase
 from oct.pages.login import LoginPage
 from oct.pages.account import AccountPage
 from oct.tests.api.registration_pattern import UserRegistration, Identity, Credentials
-from oct.tests.web.creating_emails import EmailsGeneration
 
 
 class Login(Testcase):
-    email = EmailsGeneration().creating_full_email()
+    email = Person().email()
     password = "12345678"
 
     @setup

--- a/oct/tests/web/registration.py
+++ b/oct/tests/web/registration.py
@@ -14,11 +14,11 @@ class Registration(Testcase):
         chrome: Remote = Chrome(grid)
         registration = RegisterAccountPage(chrome)
         registration.load(device)
-        generator = Person()
+        person = Person()
         registration.fill_personal_details(
-            generator.name(), generator.last_name(), generator.email(), generator.telephone()
+            person.name(), person.last_name(), person.email(), person.telephone()
         )
-        registration.fill_password(generator.password())
+        registration.fill_password(person.password())
         registration.press_continue()
         assert RegistrationSuccessPage(chrome).available()
 

--- a/tests/test_email_generation.py
+++ b/tests/test_email_generation.py
@@ -1,21 +1,17 @@
 import pytest
-import re
-from oct.tests.web.creating_emails import EmailsGeneration
+from mimesis import Person
 
 
 class TestEmailsGeneration:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self) -> None:
-        self.email = EmailsGeneration().creating_full_email()
+        self.email = Person().email()
 
     def test_length_more_then_17(self) -> None:
-        assert len(self.email) > 17
+        assert len(self.email) > 10
 
     def test_length_less_then_254(self) -> None:
         assert len(self.email) < 254
-
-    def test_find_domain_name(self) -> None:
-        assert "@mailinator.com" in self.email
 
     def test_absence_dot_dog(self) -> None:
         assert ".@" not in self.email
@@ -34,22 +30,18 @@ class TestEmailsGeneration:
         assert self.email[0].isalpha()
 
     def test_creating_emails_is_string(self) -> None:
-        assert isinstance(EmailsGeneration().creating_full_email(), str)
-
-    def test_emails_pattern(self) -> None:
-        random_email = EmailsGeneration().creating_full_email()
-        assert random_email == ((re.findall(r"\w{1,7}@\w+.\w+", random_email)).pop(0))
+        assert isinstance(Person().email(), str)
 
     def test_email_contains_dog(self) -> None:
-        assert (EmailsGeneration().creating_full_email().count("@")) == 1
+        assert (Person().email().count("@")) == 1
 
     def test_length_first_part_of_email(self) -> None:
-        assert len((EmailsGeneration().creating_full_email().split("@")).pop(0)) == 7
+        assert len((Person().email().split("@")).pop(0)) >= 4
 
     def test_second_part_of_email(self) -> None:
-        assert len((EmailsGeneration().creating_full_email().split(".")).pop(1)) <= 4
+        assert len((Person().email().split(".")).pop(1)) <= 4
 
     def test_special_symbols_are_absent(self) -> None:
         special_symbols = list(str("!$#%^&*()+=?/," "№;:?*[]{}|"))
         for each_symbol in special_symbols:
-            assert each_symbol is not EmailsGeneration().creating_full_email()
+            assert each_symbol is not Person().email()


### PR DESCRIPTION
Since now we have used in some tests a random user data generator mimesis,
it is no longer necessary to use a separate random mail generator implemente
in oct / tests / web / creating_emails.py
This commit deletes this method in all files associated with this method
and replaces it with mimesis.
Also in all files, the name of the variable generator is replaced by the person
and created test for pytest to mimesis creation email